### PR TITLE
Ajout de la taille par défaut en sortie du hasher

### DIFF
--- a/hasher.py
+++ b/hasher.py
@@ -9,7 +9,7 @@ class Hasher:
     def __init__(self):
         self.hash = hashlib.shake_128()
 
-    def hashString(self, inputString: str, size: int) -> str:
+    def hashString(self, inputString: str, size: int = 4) -> str:
         """
         Hash a given input string and return the hash value
         :param inputString: The string to hash


### PR DESCRIPTION
Ca rend plus simple pour le premier sprint (pas besoin de spécifier une taille)